### PR TITLE
PR Challenge: added Perl Min Version to compily with Kwalitee tests

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,6 @@
 use ExtUtils::MakeMaker;
 use 5.006000;
+my $mm_ver = $ExtUtils::MakeMaker::VERSION;
 
 WriteMakefile(
     'NAME'		=> 'Net::LDAP::Server',
@@ -11,6 +12,10 @@ WriteMakefile(
     	Net::LDAP => 0,
     	Convert::ASN1 => 0
     },
+    ($mm_ver >= 6.48
+        ? (MIN_PERL_VERSION => 5.006)
+        : ()
+    ),
     'dist'         	=> { COMPRESS => 'gzip', SUFFIX => 'gz' },
     'DISTNAME' => 'Net-LDAP-Server',
     'LICENSE' => 'perl',

--- a/lib/Net/LDAP/Server.pm
+++ b/lib/Net/LDAP/Server.pm
@@ -12,7 +12,7 @@
 package Net::LDAP::Server;
 use strict;
 use warnings;
-
+use 5.006000;
 use Convert::ASN1 qw(asn_read);
 use Net::LDAP::ASN qw(LDAPRequest LDAPResponse);
 use Net::LDAP::Constant qw(LDAP_OPERATIONS_ERROR LDAP_UNWILLING_TO_PERFORM);


### PR DESCRIPTION
From http://cpants.cpanauthors.org/author/AAR the distro Net::LDAP::Server fails one Kwalitee test relating to the minumum Perl version.
This change simple checks for Make Maker Version 6.48 or greater and if found sets MIN_PERL_VERSION in Makefile.PL.
Also added use 5.006000 to Server.pm
